### PR TITLE
Removes check for navigator.getUserMedia

### DIFF
--- a/getusermedia.js
+++ b/getusermedia.js
@@ -17,7 +17,7 @@ module.exports = function (constraints, cb) {
     }
 
     // treat lack of browser support like an error
-    if (typeof navigator === 'undefined' || !navigator.getUserMedia) {
+    if (typeof navigator === 'undefined') {
         // throw proper error per spec
         error = new Error('MediaStreamError');
         error.name = 'NotSupportedError';


### PR DESCRIPTION
Safari 11+ doesn't support the older navigator.getUserMedia. I verified this will fix the problem in 13.0.5. There is a shim that later catches this and handles the error in a way that works with the modern navigator.mediaDevices.getUserMedia method. 